### PR TITLE
Tweak styles for the luna-dom-highlighter div to avoid user CSS.

### DIFF
--- a/src/eruda.js
+++ b/src/eruda.js
@@ -170,6 +170,11 @@ export default {
       el.style.all = 'initial'
     }
 
+    // this needs to be done before creating shadow dom because the div is created outside of the
+    // shadow dom regardless. it needs to be early and low CSS precedence, so that the "all" can be
+    // overridden by later styles.
+    evalCss('.luna-dom-highlighter { all: initial }')
+
     let shadowRoot
     if (useShadowDom) {
       if (el.attachShadow) {


### PR DESCRIPTION
Before this PR, a file like this:

```
<div>
  <h1>hello world</h1>
</div>
<style type="text/css">
  div {
    background-color: gray;
  }
</style>
```

Gets 90% of the way to ignoring that `div` style and then has a big miss. The `luna-dom-highlighter` `div` gets embedded outside of the shadow-DOM (where the other initial is) and therefore gets styled as a solid gray block.

Resulting in this:

![image](https://user-images.githubusercontent.com/780031/190521003-0072ff54-085c-40f6-aaa2-cff54e5c6638.png)


After, it doesn't:

![image](https://user-images.githubusercontent.com/780031/190521014-620376eb-3e3d-4830-9024-f361bfeb5572.png)


Here's what that markup looks like, for good measure.

![image](https://user-images.githubusercontent.com/780031/190521070-99a74023-ee59-499f-ae82-722d7a36984c.png)

See at #1, the luna-dom-highlighter guy and at #2 the shadow DOM who is already properly reset.