### PR TITLE
attempt fix for luna-dom-highlighter using user css

### DIFF
--- a/src/eruda.js
+++ b/src/eruda.js
@@ -170,11 +170,6 @@ export default {
       el.style.all = 'initial'
     }
 
-    // this needs to be done before creating shadow dom because the div is created outside of the
-    // shadow dom regardless. it needs to be early and low CSS precedence, so that the "all" can be
-    // overridden by later styles.
-    evalCss('.luna-dom-highlighter { all: initial }')
-
     let shadowRoot
     if (useShadowDom) {
       if (el.attachShadow) {
@@ -185,8 +180,7 @@ export default {
       if (shadowRoot) {
         // font-face doesn't work inside shadow dom.
         evalCss.container = document.head
-
-        evalCss([iconStyle, lunaConsoleStyle, lunaObjectViewerStyle])
+        evalCss(['.luna-dom-highlighter { all: initial }', iconStyle, lunaConsoleStyle, lunaObjectViewerStyle])
 
         el = document.createElement('div')
         shadowRoot.appendChild(el)


### PR DESCRIPTION
turns out someone tried to fix this exact issue before, and it used to work: https://github.com/replit/eruda/pull/4

i realized this CSS rule wasn't showing up after the first `evalCss` call:
```
.luna-dom-highlighter {
  all: initial;
}
```

when i manually added this CSS (as long as it's before the other library CSS), the issue went away.

this attempts to add the CSS in a slightly different way, but testing this in replit seems pretty difficult. i also don't know how to build/publish a new version (and suspect devtools also needs a bump).