### PR TITLE
more user-style fixes

### DIFF
--- a/src/eruda.js
+++ b/src/eruda.js
@@ -170,11 +170,6 @@ export default {
       el.style.all = 'initial'
     }
 
-    // this needs to be done before creating shadow dom because the div is created outside of the
-    // shadow dom regardless. it needs to be early and low CSS precedence, so that the "all" can be
-    // overridden by later styles.
-    evalCss('.luna-dom-highlighter { all: initial }')
-
     let shadowRoot
     if (useShadowDom) {
       if (el.attachShadow) {
@@ -185,8 +180,7 @@ export default {
       if (shadowRoot) {
         // font-face doesn't work inside shadow dom.
         evalCss.container = document.head
-
-        evalCss([iconStyle, lunaConsoleStyle, lunaObjectViewerStyle])
+        evalCss(['.luna-dom-highlighter { all: initial }', iconStyle, lunaConsoleStyle, lunaObjectViewerStyle])
 
         el = document.createElement('div')
         shadowRoot.appendChild(el)

--- a/src/eruda.js
+++ b/src/eruda.js
@@ -170,6 +170,8 @@ export default {
       el.style.all = 'initial'
     }
 
+    evalCss(['.luna-dom-highlighter { all: initial; }', '.luna-dom-highlighter * { background: initial; }'])
+
     let shadowRoot
     if (useShadowDom) {
       if (el.attachShadow) {
@@ -180,7 +182,7 @@ export default {
       if (shadowRoot) {
         // font-face doesn't work inside shadow dom.
         evalCss.container = document.head
-        evalCss(['.luna-dom-highlighter { all: initial }', iconStyle, lunaConsoleStyle, lunaObjectViewerStyle])
+        evalCss([iconStyle, lunaConsoleStyle, lunaObjectViewerStyle])
 
         el = document.createElement('div')
         shadowRoot.appendChild(el)


### PR DESCRIPTION
fixed the container too.. which sadly isn't in a shadow root.
<img width="396" alt="image" src="https://github.com/liriliri/eruda/assets/1060689/ee5924c1-ac96-428d-bcf1-3fc84ed3e834">
